### PR TITLE
Silence opengl deprecations on apple builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ if (WIN32)
 	set(WIN_LIBRARIES_PATH "C:/Libraries")
 endif ()
 
+if (APPLE)
+	add_definitions(-DGL_SILENCE_DEPRECATION=1)
+endif ()
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 include_directories(external)


### PR DESCRIPTION
MacOS has "deprecated" OpenGL on Mojave and later, causing annoying (an unavoidable) build errors. Unless you want to re-write this with BGFX or Metal, this PR is the easiest way to silence them.