### PR TITLE
Add macos instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - [How to compile](#how-to-compile)
     - [Using Linux](#using-linux)
     - [Using Windows](#using-windows)
-    - [Using OSX](#using-osx)
+    - [Using MacOS](#using-macos)
 - [Discussion](#discussion)
 - [Project status](#project-status)
 - [Screenshots](#screenshots)
@@ -81,9 +81,15 @@ The long-term goal of this project is to provide a viable alternative to Minecra
 - [Wiki: Compiling on Windows using CMake and MinGW-w64](https://github.com/Unarelith/OpenMiner/wiki/Compiling-on-Windows-with-MinGW-w64)
 - [Wiki: Compiling on Windows using CMake and Visual Studio 2017](https://github.com/Unarelith/OpenMiner/wiki/Compiling-on-Windows-with-Visual-Studio-2017)
 
-### Using OSX
+### Using MacOS
 
-I don't have an OSX system at the moment. But you can help me create a guide for this OS if you have one!
+- Dependencies (using Homebrew):
+    - A compiler with C++17 support (GCC >= 7.0 or clang >= 5.0)
+    - `brew install cmake tinyxml2 glm sdl2 sdl2_mixer sdl2_ttf lua`
+    - **Optional:** `brew install ninja` (much faster builds)
+- Run `cmake -B build . && cmake --build build`; if you installed `ninja` above, add `-GNinja` before `-B` in the previous command.
+- Run the client with `./build/openminer`
+- If you want a multiplayer game, run the server with `./build/openminer_server`
 
 ## Discussion
 


### PR DESCRIPTION
Saw that you needed instructions, so I built the project and put together which deps I didn't already have. I might be missing a few on a completely vanilla machine, but for the most part I submodule _all_ of my native deps in all other projects and have a relatively vanilla global `/usr/local/lib` directory.

Hope this helps :)